### PR TITLE
fix: remove core_unix

### DIFF
--- a/nerode-learn/bin/dune
+++ b/nerode-learn/bin/dune
@@ -1,4 +1,4 @@
 (executables
  (public_names nerodelearn)
  (names main)
- (libraries core core_unix.command_unix nerode nerodelearn))
+ (libraries core nerode nerodelearn))

--- a/nerode-learn/lib/dune
+++ b/nerode-learn/lib/dune
@@ -6,6 +6,6 @@
 (library
  (name nerodelearn)
  (public_name nerodelearn)
- (libraries yojson core ounit2 nerode z3 ppxlib core_unix)
+ (libraries yojson core ounit2 nerode z3 ppxlib core_kernel.caml_unix)
  ; (preprocess (pps ppx_jane -allow-unannotated-ignores))
  )

--- a/nerode-learn/lib/lstarblanks.ml
+++ b/nerode-learn/lib/lstarblanks.ml
@@ -8,7 +8,7 @@ open ObsTbl
 
 module TWordSet = Teacher.WordSet
 
-module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type contents = ObsTbl.t) : 
+module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type contents = ObsTbl.t) :
   ActiveLearner with type teacher = Teacher.t = struct
   let learntime = ref 0.0
   let z3_time = ref 0.0
@@ -67,8 +67,8 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
     else
       begin
       Printf.printf "Dfa_size:\t%d\n%!" size;
-      Printf.printf "Popped_Items:\t%d\n%!" !popped_items; (*# of tables popped 
-        from the worklist and passed through algorithm. Tables that produce 
+      Printf.printf "Popped_Items:\t%d\n%!" !popped_items; (*# of tables popped
+        from the worklist and passed through algorithm. Tables that produce
         counterexample and are put back in head of worklist are counted twice*)
       Printf.printf "Query Count:\t%d\n%!" query_count;
       Printf.printf "Conjectures:\t%d\n%!" !conjectures;
@@ -79,13 +79,13 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
       Printf.printf "Learn Time:\t%f\n%!" !learntime;
       end
 
-  let print_cumul_metrics () = 
+  let print_cumul_metrics () =
     if CliOpt.csv () then
       () (* If we're going to csv, then the consumer can sum easily enough anyway *)
     else
       begin
-      Printf.printf "Total Popped_Items:\t%d\n%!" !cumul_popped_items; (*# of tables popped 
-        from the worklist and passed through algorithm. Tables that produce 
+      Printf.printf "Total Popped_Items:\t%d\n%!" !cumul_popped_items; (*# of tables popped
+        from the worklist and passed through algorithm. Tables that produce
         counterexample and are put back in head of worklist are counted twice*)
       Printf.printf "Total Conjectures:\t%d\n%!" !cumul_conjectures;
       Printf.printf "Total Conjecture_Time:\t%f\n%!" !cumul_conjecture_time; (*table_to_dfa+conjecture call to teacher*)
@@ -99,39 +99,39 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
   module EntryMap = WordMap
 
   type teacher = Teacher.t
-  
-  let query teacher (w : Word.t) : ObsTbl.entry = 
+
+  let query teacher (w : Word.t) : ObsTbl.entry =
     match Teacher.query teacher w with
     | None -> Blank
     | Some true -> True
     | Some false -> False
-  
+
   (*returns [true] if [w1] and [w2] not distinguishable by an added suffix.
   i.e [true] if the teacher can't show they're in different myhill-nerode classes*)
   let distinguish_conc teacher (w1: Word.t) (w2: Word.t) : bool =
     match Teacher.distinguish_concrete teacher w1 w2 with
     | None -> false
     | _ -> true
-  
-  let redisplay wl uncpre conj frac tbl : unit = 
-    if CliOpt.verbose () then 
-      begin 
-        Printf.printf "Popped:[%d] Unclosed pre-fill:[%d] Conj:[%d] 
-          Perc filled:[%.2f] UpperTblSize:[%d]\n%!" 
+
+  let redisplay wl uncpre conj frac tbl : unit =
+    if CliOpt.verbose () then
+      begin
+        Printf.printf "Popped:[%d] Unclosed pre-fill:[%d] Conj:[%d]
+          Perc filled:[%.2f] UpperTblSize:[%d]\n%!"
           wl uncpre conj frac (tbl |> ObsTbl.upper_row_labels |> RowLabels.cardinal);
         ObsTbl.print_table tbl
-      end  
+      end
 
   (** helper for [lster_blanks]. Returns a worklist, entry map pair.
-  The former is a worklist with [wl] plus, for each row in [rows_w_letter] 
-  (or for each row in [unsat_cores] if using unsat core optimization), 
+  The former is a worklist with [wl] plus, for each row in [rows_w_letter]
+  (or for each row in [unsat_cores] if using unsat core optimization),
   the table [tbl] plus the row is added to the worklist, provided its rows are
   not already in [rows_history] and a table with the same rows isn't already in
-  worklist [wl]. 
+  worklist [wl].
   The returned entry list contains the bindings of [e_map] plus any new bindings
   from queries to the teacher when building the new tables to add to [wl]*)
-  let update_worklist (rows_w_letter: RowLabels.t) (unsat_core: WordSet.t option) get_entry 
-    (tbl: ObsTbl.t) rows_history (teacher: Teacher.t) wl e_map = 
+  let update_worklist (rows_w_letter: RowLabels.t) (unsat_core: WordSet.t option) get_entry
+    (tbl: ObsTbl.t) rows_history (teacher: Teacher.t) wl e_map =
       let wl_tl = Worklist.tail wl in
 
       (*words from lower rows that will be moved up depending on optimizations*)
@@ -154,9 +154,9 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
         | Some uc -> uc (*select only lower rows that are in unsat core to move up*)
       else (*default case: all lower rows get moved up into their own table*)
         rows_w_letter in
-      
+
       let words' = if CliOpt.d_conc_on () then
-        (*using strict distiguish query (distinguishes between + and -, 
+        (*using strict distiguish query (distinguishes between + and -,
         but not +/- and blank) to narrow down tables to add*)
         let distinguishable_from_upper (w: Word.t) =
           let upper_lst = RowLabels.elements (ObsTbl.upper_row_labels tbl) in
@@ -171,12 +171,12 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
 
       (*folding over lower rows that we're moving up to make tables, that we
       enqueue to worklist, and simultaneously update the entry map [e_map]*)
-      RowLabels.fold (fun sa (wl_acc, em_acc) -> 
+      RowLabels.fold (fun sa (wl_acc, em_acc) ->
           let rows_sa = ObsTbl.upper_row_labels tbl |> RowLabels.add sa in
-          (*checks [rows_history] to see if this table 
+          (*checks [rows_history] to see if this table
           has already passed through worklist or is in worklist*)
-          if RowsSet.mem rows_sa rows_history 
-            || Worklist.exists 
+          if RowsSet.mem rows_sa rows_history
+            || Worklist.exists
               (fun tab -> ObsTbl.upper_row_labels tab |> RowLabels.equal rows_sa ) wl
           then (*table has been enqueued already in past, skip to next one*)
             begin
@@ -186,29 +186,29 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
               wl_acc, em_acc
             end
           else (*make new table with [sa] moved up, and update entry map*)
-            let t', em_acc' = ObsTbl.add_row get_entry em_acc sa tbl in 
+            let t', em_acc' = ObsTbl.add_row get_entry em_acc sa tbl in
             if CliOpt.verbose () then begin
-              Printf.printf "Enqueued to back of wl:\n%!"; 
+              Printf.printf "Enqueued to back of wl:\n%!";
               ObsTbl.print_table t' end;
             Worklist.enqueue t' wl_acc, em_acc')
         words' (wl_tl, e_map)
-  
-  (*using distinguish as replacement for validity query for teacher; 
+
+  (*using distinguish as replacement for validity query for teacher;
   terminates if the teacher has a finite set of example strings*)
-  let conjecture_by_distinguish table teacher : Word.t option = 
+  let conjecture_by_distinguish table teacher : Word.t option =
     let cols = ObsTbl.col_labels table |> ColLabels.elements |>  TWordSet.of_list in
-    ObsTbl.equivalent_pairs table |> List.fold_left 
-    (fun acc (urow, lrow) -> match acc with 
+    ObsTbl.equivalent_pairs table |> List.fold_left
+    (fun acc (urow, lrow) -> match acc with
       | None -> Teacher.distinguish teacher urow lrow cols
       | counterex -> counterex) None
 
   (**Lstar with blanks main loop*)
-  let rec lstar_blanks (alpha: Alphabet.t) ((wl : Worklist.t), rows_history, teacher, g_cols, e_map) : Dfa.t = 
+  let rec lstar_blanks (alpha: Alphabet.t) ((wl : Worklist.t), rows_history, teacher, g_cols, e_map) : Dfa.t =
     let hd_t = Worklist.head wl in
 
     let tbl, e_map = if CliOpt.global_e () then
       (*add new suffixes in global [g_cols] to popped table and update global [e_map]*)
-      let cur_cols = ObsTbl.col_labels hd_t in 
+      let cur_cols = ObsTbl.col_labels hd_t in
       let new_cols = ColLabels.diff g_cols cur_cols in
       ObsTbl.add_cols (query teacher) e_map new_cols hd_t
     (*columns not global, no need to update table or entry map*)
@@ -216,12 +216,12 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
 
     (*update metrics*)
     let () = popped_items := !popped_items + 1 in
-      redisplay 
-        !popped_items 
+      redisplay
+        !popped_items
         !unclosed_prefill
-        !conjectures 
-        ((!success_fill |> float_of_int) /. 
-          (!success_fill + !fail_fill |> float_of_int) *. 100.) 
+        !conjectures
+        ((!success_fill |> float_of_int) /.
+          (!success_fill + !fail_fill |> float_of_int) *. 100.)
         tbl;
 
     let urows = ObsTbl.upper_row_labels tbl in
@@ -230,26 +230,26 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
 
     (*checking if table can't be closed even before filling blanks (if we don't use unsat cores)*)
     match if CliOpt.uniq_on () || CliOpt.unsat_cores_on () then None else ObsTbl.closed tbl with
-    
-    | Some lower_row -> 
+
+    | Some lower_row ->
       (*unclosed before filling blanks*)
       unclosed_prefill := !unclosed_prefill + 1;
       let tbl', e_map' = ObsTbl.add_row (query teacher) e_map lower_row tbl in
       let wl' = Worklist.(wl |> tail |> enqueue tbl') in
-      if CliOpt.verbose () then begin 
+      if CliOpt.verbose () then begin
         Printf.printf "Failed to close even with blanks due to \
           row [%s]. Enqueued to back of wl:\n%!" (Word.to_string alpha lower_row);
         ObsTbl.print_table tbl' end;
       lstar_blanks alpha (wl', rows_history', teacher, g_cols, e_map')
 
     | None -> (*attempt to fill balnks with solver*)
-      let start = Core_unix.gettimeofday () in
+      let start = Caml_unix.gettimeofday () in
       let filled = Solver.fill_blanks tbl in
-      let () = z3_time := !z3_time +. (Core_unix.gettimeofday () -. start) in
-      
+      let () = z3_time := !z3_time +. (Caml_unix.gettimeofday () -. start) in
+
       match filled with
 
-        | None -> 
+        | None ->
           fail_fill := !fail_fill + 1;
           let rows_w_letter = ObsTbl.lower_row_labels tbl in
           (*add new tables to worklist and update entry map*)
@@ -265,28 +265,28 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
 
         | Some obs -> (*table successfully filled in as [obs]*)
           success_fill := !success_fill + 1;
-          if CliOpt.verbose () then 
+          if CliOpt.verbose () then
             begin
               Printf.printf "Filling blanks was successful:\n%!";
               ObsTbl.print_table obs;
               Printf.printf "Making dfa...\n%!";
             end;
           let () = conjectures := !conjectures + 1 in
-          let start = Core_unix.gettimeofday () in 
+          let start = Caml_unix.gettimeofday () in
           let dfa = ObsTbl.to_dfa obs in (*convert table to dfa*)
           if CliOpt.verbose () then begin
               Dfa.print dfa;
               Printf.printf "Conjecturing dfa...\n%!" end;
-          let result = if CliOpt.distinguish_on () 
+          let result = if CliOpt.distinguish_on ()
             then conjecture_by_distinguish obs teacher (*distinguish query*)
             else Teacher.conjecture teacher dfa in (*default validity query*)
-          let () = conjecture_time := 
-            !conjecture_time +. (Core_unix.gettimeofday () -. start) in 
-          
+          let () = conjecture_time :=
+            !conjecture_time +. (Caml_unix.gettimeofday () -. start) in
+
           match result with
 
           | None -> (*no counterexamples from conjecture, minimal dfa found*)
-            if CliOpt.distinguish_on () 
+            if CliOpt.distinguish_on ()
               (*checking to see if distinguish_blanks produced a correct DFA*)
               then begin match Teacher.conjecture teacher dfa with
                 | Some cex -> failwith "Distinguish_blanks returned an incompatible DFA! Uh-oh!"
@@ -295,61 +295,61 @@ module Make (Teacher : Teacher) (Worklist : Worklist.WorklistSig with type conte
             else dfa
 
           | Some counterex ->
-            if CliOpt.verbose () then 
+            if CliOpt.verbose () then
               Printf.printf "Conjecture rejected due to counterexample [%s]:\n%!"
                 (Word.to_string alpha counterex);
-            let start = Core_unix.gettimeofday () in
+            let start = Caml_unix.gettimeofday () in
             let e = ObsTbl.col_labels tbl in
-            let new_suffixes = counterex 
-              |> Word.suffixes 
+            let new_suffixes = counterex
+              |> Word.suffixes
               (*filter gets rid of suffixes that are already column labels in table.*)
-              |> List.filter (fun w -> not (ColLabels.mem w e)) 
-              |> ColLabels.of_list 
+              |> List.filter (fun w -> not (ColLabels.mem w e))
+              |> ColLabels.of_list
             in
-            let wl', e_map'' = if CliOpt.global_e () 
+            let wl', e_map'' = if CliOpt.global_e ()
               then (*Suffix-set shared, so only updating global E [g_cols]*)
                 wl, e_map
-              else (*adding suffixes of counterexample and 
+              else (*adding suffixes of counterexample and
               corresponding entries of columns to popped table*)
-                let tbl', e_map' = 
-                  ObsTbl.add_cols (query teacher) e_map new_suffixes tbl in 
+                let tbl', e_map' =
+                  ObsTbl.add_cols (query teacher) e_map new_suffixes tbl in
                 (*if WorklistDefault, [enquque_high_pri] adds to front of list*)
                 Worklist.(enqueue_front tbl' (tail wl)), e_map'
             in
             (*[g_cols] updated for case where we do suffix-set sharing*)
             let g_cols' = ColLabels.union g_cols new_suffixes in
-            let () = cols_update_time := 
-              !cols_update_time +. (Core_unix.gettimeofday () -. start) in 
+            let () = cols_update_time :=
+              !cols_update_time +. (Caml_unix.gettimeofday () -. start) in
             lstar_blanks alpha (wl', rows_history, teacher, g_cols', e_map'')
-  
+
   (** Entry point of L* with blanks algorithm. *)
-  let learn (alpha : Alphabet.t) teacher = 
+  let learn (alpha : Alphabet.t) teacher =
     let () = reset_metrics () in
-    let learnstart = Core_unix.gettimeofday () in
+    let learnstart = Caml_unix.gettimeofday () in
 
     (* First 1x1 table and initial entry map containg only epsilon *)
     let (tbl, e_map) : ObsTbl.t * ObsTbl.entry EntryMap.t =
       ObsTbl.init_epsilon alpha (query teacher) in
 
-    (* Worklist is implemented either as a list of tables (type ObsTbl.t) in 
-    default setting, or as a priority queue of tables in priority queue 
+    (* Worklist is implemented either as a list of tables (type ObsTbl.t) in
+    default setting, or as a priority queue of tables in priority queue
     hueristic optimization*)
     let wl : Worklist.t = Worklist.(empty |> enqueue tbl) in
 
-    (* [rows_history] is represented as a Set of RowLabels, no duplicates. As 
-    implemented now, RowsHistory maintains a history of rows of tables that 
-    have been in the worklist and have failed to be closed in the algorithm, 
+    (* [rows_history] is represented as a Set of RowLabels, no duplicates. As
+    implemented now, RowsHistory maintains a history of rows of tables that
+    have been in the worklist and have failed to be closed in the algorithm,
     to make sure tables with the same rows aren't added to the worklist again. *)
     let rows_history = RowsSet.empty in
 
-    (* [g_cols] is a set of words of type Word.t, no duplicates. It serves as 
+    (* [g_cols] is a set of words of type Word.t, no duplicates. It serves as
     the global suffix-set when the algorithm utilizes suffix-set sharing across
     tables*)
     let g_cols = ColLabels.empty in
 
     let dfa = lstar_blanks alpha (wl, rows_history, teacher, g_cols, e_map) in
     let () = learntime := (*total amount of time it took to learn dfa*)
-              !learntime +. (Core_unix.gettimeofday () -. learnstart) in
+              !learntime +. (Caml_unix.gettimeofday () -. learnstart) in
     let () = print_metrics (Dfa.size dfa) (Teacher.number_queries teacher) () in
     let () = accum_metrics () in
     let () = print_cumul_metrics () in

--- a/nerode-learn/lib/solver.ml
+++ b/nerode-learn/lib/solver.ml
@@ -96,7 +96,7 @@ let bv_of_t (t: Table.t) =
          end) in
 
   let constrain_row mk_row i acc (u,r) =
-    let get_e t = t |> Table.col_labels |> ColLabels.elements 
+    let get_e t = t |> Table.col_labels |> ColLabels.elements
       |> List.map ~f:Word.to_symlist in
     let row = mk_row i in
     declare_const solver (Id row) (BitVecSort (List.length (get_e t)));
@@ -107,11 +107,11 @@ let bv_of_t (t: Table.t) =
         let extract = extract j j (const row) in
         assert_ solver (equals term extract));
         Map.set acc ~key:u ~data:(const row) in
-  
+
   let map_conv = List.map ~f:(fun (w,elst) -> (Word.to_symlist w, elst)) in
-  let s_rows = List.foldi (map_conv (Table.up_rows_labels_entries t)) 
+  let s_rows = List.foldi (map_conv (Table.up_rows_labels_entries t))
     ~init:WordMap.empty ~f:(constrain_row s_var) in
-  let sa_rows = List.foldi (map_conv (Table.low_rows_labels_entries t)) 
+  let sa_rows = List.foldi (map_conv (Table.low_rows_labels_entries t))
     ~init:WordMap.empty ~f:(constrain_row sa_var) in
   (s_rows, sa_rows, term_of_entry)
 
@@ -139,7 +139,7 @@ let assert_consistent alpha s_rows sa_rows =
   List.iteri s ~f:(fun i si ->
     List.iteri (List.filteri s ~f:(fun j _ -> j < i)) ~f:(fun j sj ->
       List.iter alpha ~f:(fun x ->
-        assert_ solver (implies (equals (lookup si) (lookup sj)) 
+        assert_ solver (implies (equals (lookup si) (lookup sj))
                                 (equals (lookup (si@[x])) (lookup (sj@[x]))));
         )))
 
@@ -167,11 +167,11 @@ let min_rows s_rows sa_rows =
 let fill_blanks_asns (t: Table.t) assrt_lst =
   let (s_rows,sa_rows,toe) = bv_of_t t in
   let () = List.iter ~f:(fun a -> a s_rows sa_rows) assrt_lst in
-  let start = Core_unix.gettimeofday () in
+  let start = Caml_unix.gettimeofday () in
   let answer = check_sat solver in
-  let () = real_z3_time := !real_z3_time +. (Core_unix.gettimeofday () -. start) in
+  let () = real_z3_time := !real_z3_time +. (Caml_unix.gettimeofday () -. start) in
 
-  let get_results () = 
+  let get_results () =
         let results = Stdlib.Hashtbl.create 11 in
         List.iter (get_model solver) ~f:(fun (id, term) ->
         let var = Const (id) in
@@ -181,15 +181,15 @@ let fill_blanks_asns (t: Table.t) assrt_lst =
         | "(_ bv0 1)" -> Stdlib.Hashtbl.add results var false
         | _ -> ());
         results in
-  let add_lookup res w acc = 
+  let add_lookup res w acc =
     let open Table in
     let term = toe w Blank in
     let entry = if Stdlib.Hashtbl.find res term then True else False in
     CamlWordMap.add (Word.of_symlist w) entry acc in
 
   let blanks = Table.get_blanks t in
-  let results_map res = 
-    WordSet.fold (fun w -> add_lookup res (Word.to_symlist w)) 
+  let results_map res =
+    WordSet.fold (fun w -> add_lookup res (Word.to_symlist w))
     blanks CamlWordMap.empty in
 
   match answer with

--- a/nerode-learn/nerodelearn.opam
+++ b/nerode-learn/nerodelearn.opam
@@ -22,7 +22,6 @@ depends: [
   "alcotest"
   "dune" {>= "1.2"}
   "core" {>= "v0.16"}
-  "core_unix" {>= "v0.16"}
   "ounit2"
   "ppx_deriving_yojson"
   "ppx_jane" {>= "v0.16"}


### PR DESCRIPTION
JST [core_unix](https://github.com/janestreet/core_unix) keeps breaking in interesting [different ways](https://github.com/janestreet/core_unix/issues/14), and we don't really rely on anything specific to it.

Removing `core_unix` comes down to:
1. Replacing `Core_unix.gettimeofday` with `Caml_unix.gettimeofday`, the OCaml builtin.
2. Using the builtin `Arg` module for CLI parsing, instead of `core_unix.core_command`.